### PR TITLE
[misc] Config stylus caibration

### DIFF
--- a/acquisition/fCalconfig/Stylus_calibration.xml
+++ b/acquisition/fCalconfig/Stylus_calibration.xml
@@ -1,0 +1,59 @@
+<PlusConfiguration version="2.1">
+
+  <DataCollection StartupDelaySec="1.0">
+    <DeviceSet 
+      Name="Stylus_Cal: Tracking + Stylus calibration"
+      Description="No Video with Aurora tracker in Pivot calibration mode
+vtkStylusCalibrationTest uses this configuration" />
+
+	<Device
+      Id="TrackerDevice" 
+      Type="AuroraTracker"
+      SerialPort="3"
+      BaudRate="115200"
+      AcquisitionRate="50"
+      LocalTimeOffsetSec="0.0"
+      ToolReferenceFrame="Tracker" >
+      <DataSources>
+        <DataSource Type="Tool" Id="Reference" PortName="0" />
+        <DataSource Type="Tool" Id="Stylus" PortName="1" />
+      </DataSources>
+      <OutputChannels>
+        <OutputChannel Id="TrackerStream">
+          <DataSource Id="Reference" />
+          <DataSource Id="Stylus" />
+        </OutputChannel>
+      </OutputChannels>
+    </Device> 
+  </DataCollection>
+
+  <Rendering WorldCoordinateFrame="Reference">
+    <DisplayableObject Type="Model" ObjectCoordinateFrame="StylusTip" Id="StylusModel" File="Stylus_Example.stl" />
+  </Rendering>
+
+  <CoordinateDefinitions>
+  </CoordinateDefinitions>
+
+  <fCal
+    PhantomModelId="PhantomModel"
+    TransducerModelId="ProbeModel"
+    StylusModelId="StylusModel"
+    ImageDisplayableObjectId="LiveImage"
+    NumberOfStylusCalibrationPointsToAcquire="200"
+    ImageCoordinateFrame="Image"
+    ProbeCoordinateFrame="Probe"
+    ReferenceCoordinateFrame="Reference"
+    TransducerOriginCoordinateFrame="TransducerOrigin"
+    TransducerOriginPixelCoordinateFrame="TransducerOriginPixel"
+    FixedChannelId="VideoStream" 
+    FixedSourceId="Video"
+    MovingChannelId="TrackerStream"
+    MovingSourceId="ProbeToTracker"
+    DefaultSelectedChannelId="TrackerStream" />
+
+  <vtkPlusPivotCalibrationAlgo
+    ObjectMarkerCoordinateFrame="Stylus"
+    ReferenceCoordinateFrame="Reference"
+    ObjectPivotPointCoordinateFrame="StylusTip" />
+
+</PlusConfiguration>


### PR DESCRIPTION
Pivot calibration configuration between the stylus and the tracker.

Minimum error obtained during the tests: 0.195018

![img_20180720_124216219](https://user-images.githubusercontent.com/3579876/43014553-85dc5e04-8c1a-11e8-8915-b98072403f6c.jpg)




Resolves: #8 